### PR TITLE
Set compatibility with all Netbox 3.0.x versions

### DIFF
--- a/netbox_bgp/__init__.py
+++ b/netbox_bgp/__init__.py
@@ -12,7 +12,7 @@ class BGPConfig(PluginConfig):
     base_url = 'bgp'
     required_settings = []
     min_version = '3.0.0'
-    max_version = '3.0.8'
+    max_version = '3.0.99'
     default_settings = {
         'device_ext_page': 'right',
         'asdot': False


### PR DESCRIPTION
In our Kubernetes environment Netbox is automatically updating in the major version stream. So an update from 3.0.8 to 3.0.9 is done without user intervention.

With this change the plugin is compatible with all versions in the 3.0.x range.