### PR TITLE
PR to Support Netbox 3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON_VER?=3.8
-NETBOX_VER?=v3.2.4
+NETBOX_VER?=v3.3.2
 
 NAME=netbox-bgp
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This plugin provide following Models:
 | NetBox 3.0  | 0.4.3 |
 | NetBox 3.1  | 0.5.0 |
 | NetBox 3.2  | 0.6.0 |
+| Netbox 3.3  | 0.7.0 |
 
 ## Installation
 

--- a/netbox_bgp/__init__.py
+++ b/netbox_bgp/__init__.py
@@ -12,7 +12,7 @@ class BGPConfig(PluginConfig):
     base_url = 'bgp'
     required_settings = []
     min_version = '3.2.0'
-    max_version = '3.2.99'
+    max_version = '3.3.99'
     default_settings = {
         'device_ext_page': 'right',
         'asdot': False

--- a/netbox_bgp/api/serializers.py
+++ b/netbox_bgp/api/serializers.py
@@ -1,11 +1,13 @@
 from rest_framework.serializers import Serializer, HyperlinkedIdentityField, ValidationError
 from rest_framework.relations import PrimaryKeyRelatedField
 
-from netbox.api import ChoiceField, WritableNestedSerializer, ValidatedModelSerializer
+from netbox.api.fields import ChoiceField
+from netbox.api.serializers.base import ValidatedModelSerializer
 from netbox.api.serializers import NetBoxModelSerializer
+from netbox.api.serializers.nested import WritableNestedSerializer
 from dcim.api.nested_serializers import NestedSiteSerializer, NestedDeviceSerializer
 from tenancy.api.nested_serializers import NestedTenantSerializer
-from extras.api.nested_serializers import NestedTagSerializer
+from netbox.api.serializers.nested  import NestedTagSerializer
 from ipam.api.nested_serializers import NestedIPAddressSerializer
 
 


### PR DESCRIPTION
This is my first attempt at a contribution to this plugin. We are deploying ISIS/MPLS-SR currently, and this plugin is very helpful in documenting our network.

So here goes...

Netbox recently refactored the API Serializers. The BGP Plugin needs these updated to function.

I was able to test this in my development instance here. With a version bump in the __init__.py, the plugin seems to work after this change.