### PR TITLE
Extending comminuty length 64->128

### DIFF
--- a/netbox_bgp/models.py
+++ b/netbox_bgp/models.py
@@ -103,7 +103,7 @@ class Community(BGPBase):
     """
     """
     value = models.CharField(
-        max_length=64,
+        max_length=128,
         validators=[RegexValidator(r'\d+:\d+')]
     )
 


### PR DESCRIPTION
My clients sometimes use strange BGP communities.
I realize that they are not very efficient, but trying to reconfigure network during NetBox implementation is not the best thing.
As you know, regexp communities can be lengthy.
I.e.:
```
> show configuration policy-options community INTERNAL_COMMUNITY 
members "65500:([0-9]|[0-9][0-9]|[0-9][0-9][0-9]|[0-9][0-9][0-9][0-9]|[1-467890][0-9][0-9][0-9][0-9])";
```
Can you please accept this PR which extents community size twice?