### PR TITLE
fix routing policy permission name

### DIFF
--- a/netbox_bgp/templates/netbox_bgp/prefixlist.html
+++ b/netbox_bgp/templates/netbox_bgp/prefixlist.html
@@ -15,12 +15,12 @@
         <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Rule
     </a>
     {% endif %}
-    {% if perms.netbox_bgp.change_policy %}
+    {% if perms.netbox_bgp.change_routingpolicy %}
     <a href="{% url 'plugins:netbox_bgp:prefixlist_edit' pk=object.pk %}" class="btn btn-warning">
         <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
     </a>
     {% endif %}
-    {% if perms.netbox_bgp.delete_policy %}
+    {% if perms.netbox_bgp.delete_routingpolicy %}
     <a href="{% url 'plugins:netbox_bgp:prefixlist_delete' pk=object.pk %}" class="btn btn-danger">
         <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
     </a>

--- a/netbox_bgp/templates/netbox_bgp/routingpolicy.html
+++ b/netbox_bgp/templates/netbox_bgp/routingpolicy.html
@@ -10,17 +10,17 @@
 {% endblock %}
 {% block controls %}
 <div class="pull-right noprint">
-    {% if perms.netbox_bgp.change_policy %}
+    {% if perms.netbox_bgp.change_routingpolicy %}
     <a href="{% url 'plugins:netbox_bgp:routingpolicyrule_add' %}?routing_policy={{ object.pk }}" class="btn btn-success">
         <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Rule
     </a>
     {% endif %}
-    {% if perms.netbox_bgp.change_policy %}
+    {% if perms.netbox_bgp.change_routingpolicy %}
     <a href="{% url 'plugins:netbox_bgp:routingpolicy_edit' pk=object.pk %}" class="btn btn-warning">
         <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit
     </a>
     {% endif %}
-    {% if perms.netbox_bgp.delete_policy %}
+    {% if perms.netbox_bgp.delete_routingpolicy %}
     <a href="{% url 'plugins:netbox_bgp:routingpolicy_delete' pk=object.pk %}" class="btn btn-danger">
         <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete
     </a>


### PR DESCRIPTION
Non superusers can't see the buttons for "add prefix-list-rule" even if they have permissions to view, add, change and delete `netbox_bgp | routing policy rule`

The permission name is *_routingpolicy instead of *_policy.